### PR TITLE
Add -fgnu89-inline to the Sam460ex makefile.

### DIFF
--- a/board/ACube/Sam460ex/config.mk
+++ b/board/ACube/Sam460ex/config.mk
@@ -32,7 +32,8 @@ endif
 
 X86EMU =  -I../bios_emulator/scitech/include -I../bios_emulator/scitech/src/x86emu
 
-PLATFORM_CPPFLAGS += -DCONFIG_440=1 $(X86EMU) -Dprintk=printf
+# -fgnu89-inline requires gcc 4.2 (it can be omitted in previous versions)
+PLATFORM_CPPFLAGS += -DCONFIG_440=1 $(X86EMU) -Dprintk=printf -fgnu89-inline
 
 
 ifeq ($(debug),1)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -133,9 +133,9 @@ NOPEDOBJS := $(addprefix $(obj),$(NOPED_OBJ_FILES-y))
 # Use native tools and options
 # Define __KERNEL_STRICT_NAMES to prevent typedef overlaps
 #
-HOSTCPPFLAGS =	-idirafter $(SRCTREE)/include \
-		-idirafter $(OBJTREE)/include2 \
-		-idirafter $(OBJTREE)/include \
+HOSTCPPFLAGS =	-isystem $(SRCTREE)/include \
+		-isystem $(OBJTREE)/include2 \
+		-isystem $(OBJTREE)/include \
 	        -I $(SRCTREE)/lib/libfdt \
 		-I $(SRCTREE)/tools \
 		-DTEXT_BASE=$(TEXT_BASE) -DUSE_HOSTCC \


### PR DESCRIPTION
This is required when using gcc 5 or newer.

We assume that at least gcc 4.2 is used.