### PR TITLE
Decrease 5ms delay in atapi transfers to 50us for Sam460ex drivers.

### DIFF
--- a/board/ACube/common/sam_ide.c
+++ b/board/ACube/common/sam_ide.c
@@ -1150,7 +1150,8 @@ static unsigned char local_atapi_issue(int device,unsigned char* ccb,int ccblen,
 
 	local_output_data_shorts (device, (unsigned short *)ccb,ccblen/2, cc); /* write command block */
  	/* ATAPI Command written wait for completition */
-	udelay (5000); /* device must set bsy */
+	/* Was 5000 in the original firmware, for QEMU we could get rid of it */
+	udelay (50); /* device must set bsy */
 
 	mask = ATA_STAT_DRQ|ATA_STAT_BUSY|ATA_STAT_ERR;
 	/* if no data wait for DRQ = 0 BSY = 0
@@ -1208,7 +1209,8 @@ static unsigned char local_atapi_issue(int device,unsigned char* ccb,int ccblen,
 			local_input_data_shorts(device,(unsigned short *)buffer,n, cc);
 		}
 	}
-	udelay(5000); /* seems that some CD ROMs need this... */
+	/* Was 5000 in the original firmware, for QEMU we could get rid of it */
+	udelay(50); /* seems that some CD ROMs need this... */
 	mask = ATA_STAT_BUSY|ATA_STAT_ERR;
 	res=0;
 	c = local_atapi_wait_mask(device,ATAPI_TIME_OUT,mask,res, cc);


### PR DESCRIPTION
The large delay is responsible for slow loading times with the standard
slb of AmigaOS. It seems that the slb issues a command for each block, thus
each transfer could last at up to 10ms.

By decreasing the delay to 50us (which is also used in some other places),
the speed of loading kickstart is now about 100 times faster.

According to the comments, the delay makes sure that the hardware sets the
busy signal, on which the code waits to be cleared. However, for QEMU the
delays seem to be unnecessary altogether, so they could be removed. It is
unclear how this change affects real hardware, so we keep at least the 50us
delays in case anyone want to try this with real hardware.

Similar delays in other places are not changes by this patch.