### PR TITLE
 Sync latest license info from upstream u-boot

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,12 @@
-  NOTE! This copyright does *not* cover the so-called "standalone"
+  U-Boot is Free Software.  It is copyrighted by Wolfgang Denk and
+many others who contributed code (see the actual source code for
+details).  You can redistribute U-Boot and/or modify it under the
+terms of version 2 of the GNU General Public License as published by
+the Free Software Foundation.  Most of it can also be distributed,
+at your option, under any later version of the GNU General Public
+License -- see individual files for exceptions.
+
+  NOTE! This license does *not* cover the so-called "standalone"
 applications that use U-Boot services by means of the jump table
 provided by U-Boot exactly for this purpose - this is merely
 considered normal use of U-Boot, and does *not* fall under the

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,1 @@
+Licenses/gpl-2.0.txt

--- a/Licenses/Exceptions
+++ b/Licenses/Exceptions
@@ -1,0 +1,15 @@
+
+GPL License Exception:
+
+Even though U-Boot in general is covered by the GPL-2.0/GPL-2.0+,
+this does *not* cover the so-called "standalone" applications that
+use U-Boot services by means of the jump table provided by U-Boot
+exactly for this purpose - this is merely considered normal use of
+U-Boot, and does *not* fall under the heading of "derived work".
+
+  The header files "include/image.h" and "arch/*/include/asm/u-boot.h"
+define interfaces to U-Boot.  Including these (unmodified) header
+files in another file is considered normal use of U-Boot, and does
+*not* fall under the heading of "derived work".
+-- Wolfgang Denk
+

--- a/Licenses/README
+++ b/Licenses/README
@@ -1,0 +1,49 @@
+  U-Boot is Free Software.  It is copyrighted by Wolfgang Denk and
+many others who contributed code (see the actual source code and the
+git commit messages for details).  You can redistribute U-Boot and/or
+modify it under the terms of version 2 of the GNU General Public
+License as published by the Free Software Foundation.  Most of it can
+also be distributed, at your option, under any later version of the
+GNU General Public License -- see individual files for exceptions.
+
+  NOTE! This license does *not* cover the so-called "standalone"
+applications that use U-Boot services by means of the jump table
+provided by U-Boot exactly for this purpose - this is merely
+considered normal use of U-Boot, and does *not* fall under the
+heading of "derived work" -- see file  Licenses/Exceptions  for
+details.
+
+  Also note that the GPL and the other licenses are copyrighted by
+the Free Software Foundation and other organizations, but the
+instance of code that they refer to (the U-Boot source code) is
+copyrighted by me and others who actually wrote it.
+-- Wolfgang Denk
+
+
+Like many other projects, U-Boot has a tradition of including big
+blocks of License headers in all files.  This not only blows up the
+source code with mostly redundant information, but also makes it very
+difficult to generate License Clearing Reports.  An additional problem
+is that even the same licenses are referred to by a number of
+slightly varying text blocks (full, abbreviated, different
+indentation, line wrapping and/or white space, with obsolete address
+information, ...) which makes automatic processing a nightmare.
+
+To make this easier, such license headers in the source files will be
+replaced with a single line reference to Unique License Identifiers
+as defined by the Linux Foundation's SPDX project [1].  For example,
+in a source file the full "GPL v2.0 or later" header text will be
+replaced by a single line:
+
+	SPDX-License-Identifier:	GPL-2.0+
+
+We use the SPDX Unique License Identifiers here; these are available
+at [2].
+
+[1] http://spdx.org/
+[2] http://spdx.org/licenses/
+
+Full name					SPDX Identifier	OSI Approved	File name	URI
+=======================================================================================================================================
+GNU General Public License v2.0 only		GPL-2.0		Y		gpl-2.0.txt	http://www.gnu.org/licenses/gpl-2.0.txt
+GNU General Public License v2.0 or later	GPL-2.0+	Y		gpl-2.0.txt	http://www.gnu.org/licenses/gpl-2.0.txt

--- a/Licenses/gpl-2.0.txt
+++ b/Licenses/gpl-2.0.txt
@@ -1,38 +1,12 @@
-  U-Boot is Free Software.  It is copyrighted by Wolfgang Denk and
-many others who contributed code (see the actual source code for
-details).  You can redistribute U-Boot and/or modify it under the
-terms of version 2 of the GNU General Public License as published by
-the Free Software Foundation.  Most of it can also be distributed,
-at your option, under any later version of the GNU General Public
-License -- see individual files for exceptions.
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
-  NOTE! This license does *not* cover the so-called "standalone"
-applications that use U-Boot services by means of the jump table
-provided by U-Boot exactly for this purpose - this is merely
-considered normal use of U-Boot, and does *not* fall under the
-heading of "derived work".
-
-  The header files "include/image.h" and "include/asm-*/u-boot.h"
-define interfaces to U-Boot. Including these (unmodified) header
-files in another file is considered normal use of U-Boot, and does
-*not* fall under the heading of "derived work".
-
-  Also note that the GPL below is copyrighted by the Free Software
-Foundation, but the instance of code that it refers to (the U-Boot
-source code) is copyrighted by me and others who actually wrote it.
--- Wolfgang Denk
-
-=======================================================================
-
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
-
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
@@ -41,7 +15,7 @@ software--to make sure the software is free for all its users.  This
 General Public License applies to most of the Free Software
 Foundation's software and to any other program whose authors commit to
 using it.  (Some other Free Software Foundation software is covered by
-the GNU Library General Public License instead.)  You can apply it to
+the GNU Lesser General Public License instead.)  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
@@ -81,8 +55,8 @@ patent must be licensed for everyone's free use or not licensed at all.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
-
-		    GNU GENERAL PUBLIC LICENSE
+
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License applies to any program or other work which contains
@@ -136,7 +110,7 @@ above, provided that you also meet all of these conditions:
     License.  (Exception: if the Program itself is interactive but
     does not normally print such an announcement, your work based on
     the Program is not required to print an announcement.)
-
+
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
 and can be reasonably considered independent and separate works in
@@ -194,7 +168,7 @@ access to copy from a designated place, then offering equivalent
 access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
-
+
   4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
@@ -251,7 +225,7 @@ impose that choice.
 
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-
+
   8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
@@ -281,7 +255,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -303,4 +277,63 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.


### PR DESCRIPTION
This cherry-picks in various licensing clarifications from upstream u-boot that post-date the fork this repo is based off. This does not materially change the license of the code, but it does mean that github/gitlab are now able to automatically identify the correct license for the project.
